### PR TITLE
Fix bug stream

### DIFF
--- a/ai-service/app/core/graph/base.py
+++ b/ai-service/app/core/graph/base.py
@@ -19,7 +19,7 @@ from app.prompts.prompt_templates import (
     get_markdown_answer_generating_prompt_template,
     get_simple_agent_prompt_template,
     get_openai_function_prompt_template, get_human_in_loop_evaluation_prompt_template,
-    get_enhanced_prompt_template,
+    get_enhanced_prompt_template, get_regenerate_tool_calls_prompt_template,
 )
 from app.services.model_service import get_openai_model
 
@@ -166,7 +166,10 @@ class GraphBuilder:
         str_tool_message = str(state["tool_calls"])
         model = get_openai_model(temperature=0)
         model = model.bind_tools(self.tools)
-        await model.ainvoke(input=str_tool_message)
+        prompt = get_regenerate_tool_calls_prompt_template()
+        chain = prompt | model
+
+        await chain.ainvoke(input={"tool_calls": str_tool_message})
 
         data = interrupt(
             {

--- a/ai-service/app/core/utils/streaming.py
+++ b/ai-service/app/core/utils/streaming.py
@@ -21,7 +21,7 @@ class LanggraphNodeEnum(StrEnum):
     ENHANCE_PROMPT_NODE = "enhance_prompt_node"
     SELECT_TOOL_NODE = "select_tool_node"
     EVALUATE_HUMAN_IN_LOOP_NODE = "evaluate_human_in_loop_node"
-    HUMAN_REVIEW_NODE = "human_review_node"
+    HUMAN_EDITING_NODE = "human_editing_node"
     TOOL_NODE = "tool_node"
     GENERATE_NODE = "generate_node"
 
@@ -32,7 +32,7 @@ class Metadata(BaseModel):
 
 
 list_stream_nodes = [LanggraphNodeEnum.AGENT_NODE, LanggraphNodeEnum.SELECT_TOOL_NODE,
-                     LanggraphNodeEnum.HUMAN_REVIEW_NODE, LanggraphNodeEnum.GENERATE_NODE]
+                     LanggraphNodeEnum.HUMAN_EDITING_NODE, LanggraphNodeEnum.GENERATE_NODE]
 
 
 async def astream_state(

--- a/ai-service/app/prompts/prompt_templates.py
+++ b/ai-service/app/prompts/prompt_templates.py
@@ -29,6 +29,19 @@ def get_simple_agent_prompt_template():
 
 
 @lru_cache()
+def get_regenerate_tool_calls_prompt_template():
+    return PromptTemplate(
+        template="""
+You are an intelligent assistant responsible for selecting the appropriate tools based on the provided tool_calls message.
+
+## Tool Calls Message:
+{tool_calls}
+""",
+        input_variables=["tool_calls"],
+    )
+
+
+@lru_cache()
 def get_enhanced_prompt_template():
     return ChatPromptTemplate.from_messages(
         [

--- a/ai-service/app/sockets/extension_socket.py
+++ b/ai-service/app/sockets/extension_socket.py
@@ -192,7 +192,7 @@ class ExtensionNamespace(AsyncNamespace):
             async for dict_message in to_sse(response):
                 if dict_message["event"] == "metadata":
                     dict_message_data = json.loads(dict_message["data"])
-                    if dict_message_data["langgraph_node"] == LanggraphNodeEnum.HUMAN_REVIEW_NODE:
+                    if dict_message_data["langgraph_node"] == LanggraphNodeEnum.HUMAN_EDITING_NODE:
                         interrupted = True
                 elif interrupted:
                     tool_calls = convert_dict_message_to_tool_calls(dict_message)

--- a/ai-service/docs/examples/socketio_client_chat.ipynb
+++ b/ai-service/docs/examples/socketio_client_chat.ipynb
@@ -5,7 +5,7 @@
    "cell_type": "code",
    "outputs": [],
    "execution_count": null,
-   "source": "pip install python-socketio",
+   "source": "pip install python-socketio pytz",
    "id": "74bc28cd3fa423dc"
   },
   {

--- a/ai-service/docs/examples/socketio_client_stream.ipynb
+++ b/ai-service/docs/examples/socketio_client_stream.ipynb
@@ -7,7 +7,7 @@
     }
    },
    "cell_type": "code",
-   "source": "pip install python-socketio",
+   "source": "pip install python-socketio pytz",
    "id": "7e6310fd5ae21e53",
    "outputs": [],
    "execution_count": null
@@ -82,7 +82,8 @@
     "sio.connect(server_url, namespaces=[namespace])\n",
     "\n",
     "# Send a test message\n",
-    "sio.emit(\"message\", \"Hello from Jupyter!\", namespace = namespace)"
+    "sio.emit(\"message\", \"Hello from Jupyter!\", namespace = namespace)\n",
+    "input()"
    ],
    "id": "initial_id"
   },
@@ -101,7 +102,8 @@
     "    \"extension_name\": \"gmail\",\n",
     "    \"input\": \"Send a test email to fake@fake.com\"\n",
     "}\n",
-    "sio.emit(\"stream\", data, namespace=namespace)"
+    "sio.emit(\"stream\", data, namespace=namespace)\n",
+    "input()"
    ],
    "id": "3da701243173e03e"
   },


### PR DESCRIPTION
This pull request introduces several changes to the `ai-service` project, including the addition of a new prompt template, updates to the node enumeration, and modifications to example notebooks. Below are the most important changes:

### New Prompt Template Addition:
* Added `get_regenerate_tool_calls_prompt_template` function to `prompt_templates.py` to create a new prompt template for regenerating tool calls.

### Updates to Node Enumeration:
* Renamed `HUMAN_REVIEW_NODE` to `HUMAN_EDITING_NODE` in `LanggraphNodeEnum` and updated all references accordingly. [[1]](diffhunk://#diff-52c6a9534ee33399225bcd9ea01586488697db6acc736e5688b958d49421bbfbL24-R24) [[2]](diffhunk://#diff-52c6a9534ee33399225bcd9ea01586488697db6acc736e5688b958d49421bbfbL35-R35) [[3]](diffhunk://#diff-674a7b7c45ed6176d8083c1ec933be361f56f79a2f22806d4daa4d7cfe2dbe23L195-R195)

### Enhancements to Async Functionality:
* Modified `_async_human_editing_node` function in `base.py` to use the new `get_regenerate_tool_calls_prompt_template` and chain it with the model for invoking tool calls.

### Documentation and Example Updates:
* Updated example notebooks to include `pytz` in the installation commands and added `input()` calls after certain `emit` calls for better interaction. [[1]](diffhunk://#diff-ef8182916c3806d04d3c97adec8bdbaaaebdf1981f85eecf687b42c1255b9ecdL8-R8) [[2]](diffhunk://#diff-2cab5482c14b0d0daf4fad0024741f4c14bba668aa65464d5c6d00d146b0b65eL10-R10) [[3]](diffhunk://#diff-2cab5482c14b0d0daf4fad0024741f4c14bba668aa65464d5c6d00d146b0b65eL85-R86) [[4]](diffhunk://#diff-2cab5482c14b0d0daf4fad0024741f4c14bba668aa65464d5c6d00d146b0b65eL104-R106)

### Codebase Maintenance:
* Added import for the new `get_regenerate_tool_calls_prompt_template` function in `base.py`.