### PR TITLE
Add Kubernetes manifests

### DIFF
--- a/k8s/ai-database.yaml
+++ b/k8s/ai-database.yaml
@@ -1,0 +1,54 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ai-database-config
+  namespace: default
+data:
+  POSTGRES_DB: "ai-database"
+  POSTGRES_USER: "postgres"
+  POSTGRES_PASSWORD: "123456"
+  POSTGRES_HOST: "ai-database"
+  POSTGRES_PORT: "5432"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ai-database
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: ai-database
+  template:
+    metadata:
+      labels:
+        app: ai-database
+    spec:
+      containers:
+        - name: ai-database
+          image: pgvector/pgvector:pg16
+          ports:
+            - containerPort: 5432
+          envFrom:
+            - configMapRef:
+                name: ai-database-config
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/postgresql/data
+      volumes:
+        - name: data
+          emptyDir: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ai-database
+  namespace: default
+spec:
+  selector:
+    app: ai-database
+  ports:
+    - protocol: TCP
+      port: 5432
+      targetPort: 5432

--- a/k8s/ai-service.yaml
+++ b/k8s/ai-service.yaml
@@ -1,0 +1,60 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ai-service-config
+  namespace: default
+data:
+  DEBUG_AGENT: "False"
+  DEBUG_SERVER: "False"
+  DEBUG_SQLALCHEMY: "False"
+  LOGGING_LOG_LEVEL: "INFO"
+  LLM_DEFAULT_PROVIDER: "openai"
+  LLM_DEFAULT_MODEL: "gpt-4o-mini"
+  LLM_DEFAULT_API_KEY: "<YOUR_OPENAI_API_KEY>"
+  POSTGRES_HOST: "ai-database"
+  POSTGRES_PORT: "5432"
+  POSTGRES_USER: "postgres"
+  POSTGRES_PASSWORD: "123456"
+  POSTGRES_DB: "ai-database"
+  TOOL_TAVILY_API_KEY: "<YOUR_TAVILY_API_KEY>"
+  COMPOSIO_LOGGING_LEVEL: "debug"
+  COMPOSIO_API_KEY: "<YOUR_COMPOSIO_API_KEY>"
+  COMPOSIO_REDIRECT_URL: "https://localhost:15000/ai/api/v1/callback/extension"
+  FRONTEND_REDIRECT_URL: "http://localhost:3000/callback/extension"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ai-service
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: ai-service
+  template:
+    metadata:
+      labels:
+        app: ai-service
+    spec:
+      containers:
+        - name: ai-service
+          image: aagent.azurecr.io/ai-service:stg
+          ports:
+            - containerPort: 15200
+          envFrom:
+            - configMapRef:
+                name: ai-service-config
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ai-service
+  namespace: default
+spec:
+  selector:
+    app: ai-service
+  ports:
+    - protocol: TCP
+      port: 15200
+      targetPort: 15200

--- a/k8s/api-gateway.yaml
+++ b/k8s/api-gateway.yaml
@@ -1,0 +1,52 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: api-gateway-config
+  namespace: default
+data:
+  HTTPS_PORT: "15000"
+  SSL_KEY_PATH: "certs/key.pem"
+  SSL_CERT_PATH: "certs/cert.pem"
+  USER_SERVICE_URL: "http://user-service:15100"
+  AI_SERVICE_URL: "http://ai-service:15200"
+  ELASTICSEARCH_URL: "http://elasticsearch:9200"
+  RABBITMQ_URL: "amqp://root:root@rabbitmq:5672"
+  REDIS_URL: "redis://root:root@redis:6379"
+  MICROSERVICE_TIMEOUT: "300000"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: api-gateway
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: api-gateway
+  template:
+    metadata:
+      labels:
+        app: api-gateway
+    spec:
+      containers:
+        - name: api-gateway
+          image: aagent.azurecr.io/api-gateway:stg
+          ports:
+            - containerPort: 15000
+          envFrom:
+            - configMapRef:
+                name: api-gateway-config
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: api-gateway
+  namespace: default
+spec:
+  selector:
+    app: api-gateway
+  ports:
+    - protocol: TCP
+      port: 15000
+      targetPort: 15000

--- a/k8s/elasticsearch.yaml
+++ b/k8s/elasticsearch.yaml
@@ -1,0 +1,55 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: elasticsearch-config
+  namespace: default
+data:
+  discovery.type: "single-node"
+  ES_JAVA_OPTS: "-Xms1g -Xmx1g"
+  xpack.security.enabled: "false"
+  http.host: "0.0.0.0"
+  transport.host: "127.0.0.1"
+  xpack.security.http.ssl.enabled: "false"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: elasticsearch
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: elasticsearch
+  template:
+    metadata:
+      labels:
+        app: elasticsearch
+    spec:
+      containers:
+        - name: elasticsearch
+          image: docker.elastic.co/elasticsearch/elasticsearch:8.16.1
+          ports:
+            - containerPort: 9200
+          envFrom:
+            - configMapRef:
+                name: elasticsearch-config
+          volumeMounts:
+            - name: data
+              mountPath: /usr/share/elasticsearch/data
+      volumes:
+        - name: data
+          emptyDir: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: elasticsearch
+  namespace: default
+spec:
+  selector:
+    app: elasticsearch
+  ports:
+    - protocol: TCP
+      port: 9200
+      targetPort: 9200

--- a/k8s/extension-database.yaml
+++ b/k8s/extension-database.yaml
@@ -1,0 +1,52 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: extension-database-config
+  namespace: default
+data:
+  MONGO_INITDB_ROOT_USERNAME: "root"
+  MONGO_INITDB_ROOT_PASSWORD: "root"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: extension-database
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: extension-database
+  template:
+    metadata:
+      labels:
+        app: extension-database
+    spec:
+      containers:
+        - name: extension-database
+          image: mongo:latest
+          ports:
+            - containerPort: 27017
+          envFrom:
+            - configMapRef:
+                name: extension-database-config
+          volumeMounts:
+            - name: data
+              mountPath: /data/db
+      volumes:
+        - name: data
+          emptyDir: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: extension-database
+  namespace: default
+spec:
+  selector:
+    app: extension-database
+  ports:
+    - protocol: TCP
+      port: 27017
+      targetPort: 27017
+

--- a/k8s/extension-service.yaml
+++ b/k8s/extension-service.yaml
@@ -1,0 +1,49 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: extension-service-config
+  namespace: default
+data:
+  NODE_ENV: "dev"
+  PORT: "15300"
+  COMPOSIO_API_BASE_URL: "https://backend.composio.dev/api"
+  COMPOSIO_API_KEY: "d04n821zcnqtop53g98fx"
+  DATABASE_URL: "mongodb://root:root@extension-database:27017/datn-extension-database?authSource=admin"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: extension-service
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: extension-service
+  template:
+    metadata:
+      labels:
+        app: extension-service
+    spec:
+      containers:
+        - name: extension-service
+          image: aagent.azurecr.io/extension-service:stg
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 15300
+          envFrom:
+            - configMapRef:
+                name: extension-service-config
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: extension-service
+  namespace: default
+spec:
+  selector:
+    app: extension-service
+  ports:
+    - protocol: TCP
+      port: 15300
+      targetPort: 15300

--- a/k8s/kibana.yaml
+++ b/k8s/kibana.yaml
@@ -1,0 +1,46 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kibana-config
+  namespace: default
+data:
+  ELASTICSEARCH_HOSTS: "http://elasticsearch:9200"
+  SERVER_NAME: "kibana"
+  XPACK_SECURITY_ENABLED: "false"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kibana
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: kibana
+  template:
+    metadata:
+      labels:
+        app: kibana
+    spec:
+      containers:
+        - name: kibana
+          image: docker.elastic.co/kibana/kibana:8.16.1
+          ports:
+            - containerPort: 5601
+          envFrom:
+            - configMapRef:
+                name: kibana-config
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: kibana
+  namespace: default
+spec:
+  selector:
+    app: kibana
+  ports:
+    - protocol: TCP
+      port: 5601
+      targetPort: 5601

--- a/k8s/rabbitmq.yaml
+++ b/k8s/rabbitmq.yaml
@@ -1,0 +1,59 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: rabbitmq-config
+  namespace: default
+data:
+  RABBITMQ_DEFAULT_USER: "root"
+  RABBITMQ_DEFAULT_PASS: "root"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: rabbitmq
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: rabbitmq
+  template:
+    metadata:
+      labels:
+        app: rabbitmq
+    spec:
+      containers:
+        - name: rabbitmq
+          image: rabbitmq:3-management
+          ports:
+            - containerPort: 5672
+            - containerPort: 15672
+            - containerPort: 15692
+          envFrom:
+            - configMapRef:
+                name: rabbitmq-config
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/rabbitmq
+      volumes:
+        - name: data
+          emptyDir: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: rabbitmq
+  namespace: default
+spec:
+  selector:
+    app: rabbitmq
+  ports:
+    - protocol: TCP
+      port: 5672
+      targetPort: 5672
+    - protocol: TCP
+      port: 15672
+      targetPort: 15672
+    - protocol: TCP
+      port: 15692
+      targetPort: 15692

--- a/k8s/redis.yaml
+++ b/k8s/redis.yaml
@@ -1,0 +1,53 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: redis-config
+  namespace: default
+data:
+  REDIS_HOST: "redis"
+  REDIS_PORT: "6379"
+  REDIS_USER: "root"
+  REDIS_PASSWORD: "root"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redis
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: redis
+  template:
+    metadata:
+      labels:
+        app: redis
+    spec:
+      containers:
+        - name: redis
+          image: redis:latest
+          ports:
+            - containerPort: 6379
+          envFrom:
+            - configMapRef:
+                name: redis-config
+          volumeMounts:
+            - name: data
+              mountPath: /data
+      volumes:
+        - name: data
+          emptyDir: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis
+  namespace: default
+spec:
+  selector:
+    app: redis
+  ports:
+    - protocol: TCP
+      port: 6379
+      targetPort: 6379

--- a/k8s/user-database.yaml
+++ b/k8s/user-database.yaml
@@ -1,0 +1,51 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: user-database-config
+  namespace: default
+data:
+  MONGO_INITDB_ROOT_USERNAME: "root"
+  MONGO_INITDB_ROOT_PASSWORD: "root"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: user-database
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: user-database
+  template:
+    metadata:
+      labels:
+        app: user-database
+    spec:
+      containers:
+        - name: user-database
+          image: mongo:latest
+          ports:
+            - containerPort: 27017
+          envFrom:
+            - configMapRef:
+                name: user-database-config
+          volumeMounts:
+            - name: data
+              mountPath: /data/db
+      volumes:
+        - name: data
+          emptyDir: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: user-database
+  namespace: default
+spec:
+  selector:
+    app: user-database
+  ports:
+    - protocol: TCP
+      port: 27017
+      targetPort: 27017

--- a/k8s/user-service.yaml
+++ b/k8s/user-service.yaml
@@ -1,0 +1,62 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: user-service-config
+  namespace: default
+data:
+  NODE_ENV: "dev"
+  PORT: "15100"
+  MONGODB_CONNECTION_STRING: "mongodb://root:root@user-database:27017/user-service?authSource=admin"
+  EMAIL_USERNAME: "<EMAIL_USERNAME>"
+  EMAIL_PASSWORD: "<EMAIL_PASSWORD>"
+  GOOGLE_APP_CLIENT_ID: "<YOUR_GOOGLE_CLIENT_ID>"
+  GOOGLE_APP_CLIENT_SECRET: "<YOUR_GOOGLE_CLIENT_SECRET>"
+  GOOGLE_APP_REDIRECT_URL: "https://localhost:15000/user/api/v1/access/auth/google/grant-gmail-permission/callback"
+  FACEBOOK_APP_CLIENT_ID: "<YOUR_FACEBOOK_CLIENT_ID>"
+  FACEBOOK_APP_CLIENT_SECRET: "<YOUR_FACEBOOK_CLIENT_SECRET>"
+  FACEBOOK_APP_REDIRECT_URL: "https://localhost:15000/user/api/v1/access/facebook/verify"
+  API_GATEWAY_URL: "https://localhost:15000"
+  AI_SERVICE_URL: "http://ai-service:15200"
+  JWT_SECRET: "c667d2a6dfcc7fbf5efe64de40fdf3e37dc8a00c1311cf9c449922cb92e4858e0d7c0fa010c883c4ff3edeb89ccfd72c3fc7b9cdd287c7da2e163bde933b1cca"
+  CLIENT_URL: "http://localhost:3000"
+  REDIS_HOST: "redis"
+  REDIS_PORT: "6379"
+  REDIS_USER: "default"
+  REDIS_PASSWORD: "root"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: user-service
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: user-service
+  template:
+    metadata:
+      labels:
+        app: user-service
+    spec:
+      containers:
+        - name: user-service
+          image: aagent.azurecr.io/user-service:stg
+          ports:
+            - containerPort: 15100
+          envFrom:
+            - configMapRef:
+                name: user-service-config
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: user-service
+  namespace: default
+spec:
+  selector:
+    app: user-service
+  ports:
+    - protocol: TCP
+      port: 15100
+      targetPort: 15100


### PR DESCRIPTION
## Summary
- translate docker compose services into Kubernetes YAML
- create deployment and service definitions with environment ConfigMaps
- update extension-service to use registry image and reference new MongoDB
- add extension-database manifest
- fix extension database host name

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6849c615ab94832586690f572ad4b0d2