### PR TITLE
Add k8s secrets and update deployments

### DIFF
--- a/k8s/ai-service/db-deployment.yaml
+++ b/k8s/ai-service/db-deployment.yaml
@@ -1,0 +1,62 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: ai-database-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ai-database
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: ai-database
+  template:
+    metadata:
+      labels:
+        app: ai-database
+    spec:
+      containers:
+        - name: ai-database
+          image: pgvector/pgvector:pg16
+          ports:
+            - containerPort: 5432
+          env:
+            - name: POSTGRES_DB
+              value: ai-database
+            - name: POSTGRES_USER
+              valueFrom:
+                secretKeyRef:
+                  name: ai-db-secret
+                  key: POSTGRES_USER
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: ai-db-secret
+                  key: POSTGRES_PASSWORD
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/postgresql/data
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: ai-database-pvc
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ai-database
+spec:
+  selector:
+    app: ai-database
+  ports:
+    - protocol: TCP
+      port: 5432
+      targetPort: 5432

--- a/k8s/ai-service/db-secret.yaml
+++ b/k8s/ai-service/db-secret.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: ai-db-secret
+type: Opaque
+stringData:
+  POSTGRES_USER: "postgres"
+  POSTGRES_PASSWORD: "123456"

--- a/k8s/ai-service/deployment.yaml
+++ b/k8s/ai-service/deployment.yaml
@@ -1,0 +1,67 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ai-service
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: ai-service
+  template:
+    metadata:
+      labels:
+        app: ai-service
+    spec:
+      containers:
+        - name: ai-service
+          image: aagent.azurecr.io/ai-service:stg
+          ports:
+            - containerPort: 15200
+          env:
+            - name: DEBUG_AGENT
+              value: "False"
+            - name: DEBUG_SERVER
+              value: "False"
+            - name: DEBUG_SQLALCHEMY
+              value: "False"
+            - name: LOGGING_LOG_LEVEL
+              value: INFO
+            - name: LLM_DEFAULT_PROVIDER
+              value: openai
+            - name: LLM_DEFAULT_MODEL
+              value: gpt-4o-mini
+            - name: POSTGRES_HOST
+              value: ai-database
+            - name: POSTGRES_PORT
+              value: "5432"
+            - name: POSTGRES_USER
+              valueFrom:
+                secretKeyRef:
+                  name: ai-db-secret
+                  key: POSTGRES_USER
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: ai-db-secret
+                  key: POSTGRES_PASSWORD
+            - name: POSTGRES_DB
+              value: ai-database
+            - name: COMPOSIO_LOGGING_LEVEL
+              value: debug
+            - name: COMPOSIO_REDIRECT_URL
+              value: https://localhost:15000/ai/api/v1/callback/extension
+            - name: FRONTEND_REDIRECT_URL
+              value: http://localhost:3000/callback/extension
+      restartPolicy: Always
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ai-service
+spec:
+  selector:
+    app: ai-service
+  ports:
+    - protocol: TCP
+      port: 15200
+      targetPort: 15200

--- a/k8s/api-gateway/deployment.yaml
+++ b/k8s/api-gateway/deployment.yaml
@@ -1,0 +1,59 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: api-gateway
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: api-gateway
+  template:
+    metadata:
+      labels:
+        app: api-gateway
+    spec:
+      containers:
+        - name: api-gateway
+          image: aagent.azurecr.io/api-gateway:stg
+          ports:
+            - containerPort: 15000
+          env:
+            - name: HTTPS_PORT
+              value: "15000"
+            - name: USER_SERVICE_URL
+              value: http://user-service:15100
+            - name: AI_SERVICE_URL
+              value: http://ai-service:15200
+            - name: ELASTICSEARCH_URL
+              value: http://elasticsearch:9200
+            - name: RABBITMQ_URL
+              valueFrom:
+                secretKeyRef:
+                  name: api-gateway-secret
+                  key: RABBITMQ_URL
+            - name: REDIS_URL
+              valueFrom:
+                secretKeyRef:
+                  name: api-gateway-secret
+                  key: REDIS_URL
+            - name: MICROSERVICE_TIMEOUT
+              value: "300000"
+          volumeMounts:
+            - name: certs
+              mountPath: /usr/src/app/certs
+              readOnly: true
+      volumes:
+        - name: certs
+          emptyDir: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: api-gateway
+spec:
+  selector:
+    app: api-gateway
+  ports:
+    - protocol: TCP
+      port: 15000
+      targetPort: 15000

--- a/k8s/api-gateway/secret.yaml
+++ b/k8s/api-gateway/secret.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: api-gateway-secret
+type: Opaque
+stringData:
+  RABBITMQ_URL: "amqp://root:root@rabbitmq:5672"
+  REDIS_URL: "redis://root:root@redis:6379"

--- a/k8s/extension-service/deployment.yaml
+++ b/k8s/extension-service/deployment.yaml
@@ -1,0 +1,43 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: extension-service
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: extension-service
+  template:
+    metadata:
+      labels:
+        app: extension-service
+    spec:
+      containers:
+        - name: extension-service
+          image: aagent.azurecr.io/extension-service:stg
+          ports:
+            - containerPort: 15300
+          env:
+            - name: NODE_ENV
+              value: dev
+            - name: PORT
+              value: "15300"
+            - name: COMPOSIO_API_BASE_URL
+              value: https://backend.composio.dev/api
+            - name: COMPOSIO_API_KEY
+              value: d04n821zcnqtop53g98fx
+            - name: DATABASE_URL
+              value: mongodb://localhost:27017/datn-extension-database
+      restartPolicy: Always
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: extension-service
+spec:
+  selector:
+    app: extension-service
+  ports:
+    - protocol: TCP
+      port: 15300
+      targetPort: 15300

--- a/k8s/user-service/db-deployment.yaml
+++ b/k8s/user-service/db-deployment.yaml
@@ -1,0 +1,60 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: user-database-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: user-database
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: user-database
+  template:
+    metadata:
+      labels:
+        app: user-database
+    spec:
+      containers:
+        - name: user-database
+          image: mongo:latest
+          ports:
+            - containerPort: 27017
+          env:
+            - name: MONGO_INITDB_ROOT_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: user-db-secret
+                  key: MONGO_INITDB_ROOT_USERNAME
+            - name: MONGO_INITDB_ROOT_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: user-db-secret
+                  key: MONGO_INITDB_ROOT_PASSWORD
+          volumeMounts:
+            - name: data
+              mountPath: /data/db
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: user-database-pvc
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: user-database
+spec:
+  selector:
+    app: user-database
+  ports:
+    - protocol: TCP
+      port: 27017
+      targetPort: 27017

--- a/k8s/user-service/db-secret.yaml
+++ b/k8s/user-service/db-secret.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: user-db-secret
+type: Opaque
+stringData:
+  MONGO_INITDB_ROOT_USERNAME: "root"
+  MONGO_INITDB_ROOT_PASSWORD: "root"

--- a/k8s/user-service/deployment.yaml
+++ b/k8s/user-service/deployment.yaml
@@ -1,0 +1,64 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: user-service
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: user-service
+  template:
+    metadata:
+      labels:
+        app: user-service
+    spec:
+      containers:
+        - name: user-service
+          image: aagent.azurecr.io/user-service:stg
+          ports:
+            - containerPort: 15100
+          env:
+            - name: NODE_ENV
+              value: dev
+            - name: PORT
+              value: "15100"
+            - name: MONGODB_CONNECTION_STRING
+              valueFrom:
+                secretKeyRef:
+                  name: user-service-secret
+                  key: MONGODB_CONNECTION_STRING
+            - name: JWT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: user-service-secret
+                  key: JWT_SECRET
+            - name: REDIS_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: user-service-secret
+                  key: REDIS_PASSWORD
+            - name: API_GATEWAY_URL
+              value: https://localhost:15000
+            - name: AI_SERVICE_URL
+              value: http://ai-service:15200
+            - name: CLIENT_URL
+              value: http://localhost:3000
+            - name: REDIS_HOST
+              value: redis
+            - name: REDIS_PORT
+              value: "6379"
+            - name: REDIS_USER
+              value: default
+      restartPolicy: Always
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: user-service
+spec:
+  selector:
+    app: user-service
+  ports:
+    - protocol: TCP
+      port: 15100
+      targetPort: 15100

--- a/k8s/user-service/secret.yaml
+++ b/k8s/user-service/secret.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: user-service-secret
+type: Opaque
+stringData:
+  MONGODB_CONNECTION_STRING: "mongodb://root:root@user-database:27017/user-service?authSource=admin"
+  JWT_SECRET: "c667d2a6dfcc7fbf5efe64de40fdf3e37dc8a00c1311cf9c449922cb92e4858e0d7c0fa010c883c4ff3edeb89ccfd72c3fc7b9cdd287c7da2e163bde933b1cca"
+  REDIS_PASSWORD: "root"


### PR DESCRIPTION
## Summary
- add Kubernetes deployment and service manifests
- create secrets for DB passwords and JWTs
- reference secrets in deployment environment variables
- organize k8s manifests in dedicated folders per service

## Testing
- `npm test --silent` in `user-service` *(fails: jest not found)*
- `npm test --silent` in `extension-service` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849d0925d5483259c415af4033a2abb